### PR TITLE
Log db query count

### DIFF
--- a/lib/chitragupta.rb
+++ b/lib/chitragupta.rb
@@ -57,6 +57,9 @@ module Chitragupta
         require "chitragupta/request_log_formatter"
         config.lograge.enabled = true
         config.lograge.formatter = RequestLogFormatter::FORMAT
+        config.lograge.custom_options = lambda do |event|
+          {:query_count => event.payload[:query_count]}
+        end
       end
 
       # setting the log_tags to empty array to ensure that the message being generated does not contain the unwanted tags

--- a/lib/chitragupta/util.rb
+++ b/lib/chitragupta/util.rb
@@ -64,6 +64,7 @@ module Chitragupta
 
       data[:data][:response][:view_rendering_duration] = message[:view] rescue nil
       data[:data][:response][:db_query_duration] = message[:db] rescue nil
+      data[:data][:response][:db_query_count] = message[:query_count] rescue nil
     end
 
     def populate_ruby_server_data(data, message)

--- a/lib/chitragupta/version.rb
+++ b/lib/chitragupta/version.rb
@@ -1,3 +1,3 @@
 module Chitragupta
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end

--- a/spec/chitragupta/util_spec.rb
+++ b/spec/chitragupta/util_spec.rb
@@ -93,7 +93,8 @@ RSpec.describe Chitragupta::Util do
                   status: nil,
                   duration: nil,
                   view_rendering_duration: nil,
-                  db_query_duration: nil
+                  db_query_duration: nil,
+                  db_query_count: nil
               }
           },
           meta: {
@@ -124,7 +125,8 @@ RSpec.describe Chitragupta::Util do
                   status: 200,
                   duration: 10.01,
                   view_rendering_duration: 12.34,
-                  db_query_duration: 0.09
+                  db_query_duration: 0.09,
+                  db_query_count: 10
               }
           },
           meta: {
@@ -137,7 +139,8 @@ RSpec.describe Chitragupta::Util do
           status: 200,
           duration: 10.01,
           view: 12.34,
-          db: 0.09
+          db: 0.09,
+          query_count: 10
       }
       Chitragupta::Util.send(:populate_rails_server_data, data, message)
       expect(data).to eq(expected_output)


### PR DESCRIPTION
As part of RDS performance analysis, we wan to track the number of DB queries fired per route. These will be sent from rails -> Chitragupta. Later these can be used for visualization.

Jira ticket: https://browserstack.atlassian.net/browse/LIVE-9882