### PR TITLE
fix for sidekiq>6

### DIFF
--- a/lib/chitragupta/util.rb
+++ b/lib/chitragupta/util.rb
@@ -92,9 +92,14 @@ module Chitragupta
       if Thread.current[:sidekiq_context].nil?
         return
       end
-      worker_name, job_id = Thread.current[:sidekiq_context][0].split
-      data[:data][:job_id] = job_id
-      data[:data][:worker_name] = worker_name
+      if Thread.current[:sidekiq_context].is_a?(Hash)
+        data[:data][:job_id] = Thread.current[:sidekiq_context][:jid]
+        data[:data][:worker_name] = Thread.current[:sidekiq_context][:class]
+      else
+        worker_name, job_id = Thread.current[:sidekiq_context][0].split
+        data[:data][:job_id] = job_id
+        data[:data][:worker_name] = worker_name
+      end
     end
 
     def initialize_data(message)


### PR DESCRIPTION
Logs for sidekiq didnt contain worker_name and job_id if sidekiq version > 6. Fixed it
Before:
<img width="1254" alt="Screenshot 2024-07-12 at 3 44 20 PM" src="https://github.com/user-attachments/assets/2c3ecd6e-5a9c-4b04-b5e4-c13bfeadc90a">
After:
<img width="1253" alt="Screenshot 2024-07-17 at 3 17 53 PM" src="https://github.com/user-attachments/assets/13412329-42fc-4a92-9ef9-9357232e912b">
