### PR TITLE
Fix logging context leaks and parameter encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Chitragupta.payload = {
   'ip': request.ip,
   'request_id': 1234, # Request ID goes here
   'user_id': 1, # Requesting user ID goes here
-  # Rack/Sinatra params are unfiltered; drop credential-bearing keys before logging them
-  'params': request.params.reject { |key, _| key =~ /password|token|secret|api_key/i }
+  # The gem logs whatever it is given, and Rack/Sinatra params are unfiltered, so pass
+  # a copy your application has already run through its own parameter filter
+  'params': app_filtered_params(request.params)
 }
 cg_logger.info({"status": 200, # status code of server request
                 "duration": 100,

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Chitragupta.payload = {
   'ip': request.ip,
   'request_id': 1234, # Request ID goes here
   'user_id': 1, # Requesting user ID goes here
-  'params': request.params
+  # Rack/Sinatra params are unfiltered; drop credential-bearing keys before logging them
+  'params': request.params.reject { |key, _| key =~ /password|token|secret|api_key/i }
 }
 cg_logger.info({"status": 200, # status code of server request
                 "duration": 100,

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ cg_logger = Logger.new('/tmp/already_existing_logfile.log')
 cg_logger.formatter = Chitragupta::JsonLogFormatter.new
 
 # for sinatra application
+require "chitragupta/middleware"
+use Chitragupta::Middleware
+
 Chitragupta.payload = {
   'method': request.request_method,
   'path': request.path_info,

--- a/lib/chitragupta.rb
+++ b/lib/chitragupta.rb
@@ -63,8 +63,10 @@ module Chitragupta
       config.log_formatter = JsonLogFormatter.new if Chitragupta::Util.called_as_rails_server? || Chitragupta::Util.called_as_rake? || Chitragupta::Util.called_as_sidekiq?
       if Chitragupta::Util.called_as_rails_server?
         require "chitragupta/request_log_formatter"
+        require "chitragupta/middleware"
         config.lograge.enabled = true
         config.lograge.formatter = RequestLogFormatter::FORMAT
+        config.middleware.insert_after ActionDispatch::RequestId, Chitragupta::Middleware
       end
 
       # setting the log_tags to empty array to ensure that the message being generated does not contain the unwanted tags

--- a/lib/chitragupta.rb
+++ b/lib/chitragupta.rb
@@ -66,7 +66,7 @@ module Chitragupta
         require "chitragupta/middleware"
         config.lograge.enabled = true
         config.lograge.formatter = RequestLogFormatter::FORMAT
-        config.middleware.insert_after ActionDispatch::RequestId, Chitragupta::Middleware
+        config.middleware.unshift Chitragupta::Middleware
       end
 
       # setting the log_tags to empty array to ensure that the message being generated does not contain the unwanted tags

--- a/lib/chitragupta.rb
+++ b/lib/chitragupta.rb
@@ -66,7 +66,9 @@ module Chitragupta
         require "chitragupta/middleware"
         config.lograge.enabled = true
         config.lograge.formatter = RequestLogFormatter::FORMAT
-        config.middleware.use Chitragupta::Middleware
+        # Outermost: index 0 needs no reference middleware, so it is safe on Rails 4.0,
+        # and the exit clear then runs after exception-logging middleware has read the context.
+        config.middleware.insert_before 0, Chitragupta::Middleware
       end
 
       # setting the log_tags to empty array to ensure that the message being generated does not contain the unwanted tags

--- a/lib/chitragupta.rb
+++ b/lib/chitragupta.rb
@@ -66,7 +66,7 @@ module Chitragupta
         require "chitragupta/middleware"
         config.lograge.enabled = true
         config.lograge.formatter = RequestLogFormatter::FORMAT
-        config.middleware.unshift Chitragupta::Middleware
+        config.middleware.use Chitragupta::Middleware
       end
 
       # setting the log_tags to empty array to ensure that the message being generated does not contain the unwanted tags

--- a/lib/chitragupta/active_support/instrumentation.rb
+++ b/lib/chitragupta/active_support/instrumentation.rb
@@ -13,8 +13,7 @@ module ActionController
         :path       => (request.fullpath.split("?")[0] rescue "unknown"),
         :request_id => request.uuid,
         :ip         => request.remote_ip,
-        :log_id    => (request.headers['X-Chitragupta-log-id'] rescue nil),
-        :request_source => (request.headers['request-source'] rescue nil)
+        :log_id    => (request.headers['X-Chitragupta-log-id'] rescue nil)
       }
 
       ActiveSupport::Notifications.instrument("start_processing.action_controller", raw_payload.dup)

--- a/lib/chitragupta/middleware.rb
+++ b/lib/chitragupta/middleware.rb
@@ -1,0 +1,12 @@
+module Chitragupta
+  class Middleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      Chitragupta.payload = {}
+      @app.call(env)
+    end
+  end
+end

--- a/lib/chitragupta/middleware.rb
+++ b/lib/chitragupta/middleware.rb
@@ -7,6 +7,8 @@ module Chitragupta
     def call(env)
       Chitragupta.payload = {}
       @app.call(env)
+    ensure
+      Chitragupta.payload = {}
     end
   end
 end

--- a/lib/chitragupta/middleware.rb
+++ b/lib/chitragupta/middleware.rb
@@ -1,3 +1,5 @@
+require "rack/body_proxy"
+
 module Chitragupta
   class Middleware
     def initialize(app)
@@ -6,9 +8,11 @@ module Chitragupta
 
     def call(env)
       Chitragupta.payload = {}
-      @app.call(env)
-    ensure
+      status, headers, body = @app.call(env)
+      [status, headers, Rack::BodyProxy.new(body) { Chitragupta.payload = {} }]
+    rescue Exception
       Chitragupta.payload = {}
+      raise
     end
   end
 end

--- a/lib/chitragupta/rake/application.rb
+++ b/lib/chitragupta/rake/application.rb
@@ -1,6 +1,20 @@
 require 'rake'
 module Rake
   class Application
-    attr_accessor :current_task, :execution_id
+    def current_task
+      Thread.current[:chitragupta_rake_current_task]
+    end
+
+    def current_task=(task)
+      Thread.current[:chitragupta_rake_current_task] = task
+    end
+
+    def execution_id
+      Thread.current[:chitragupta_rake_execution_id]
+    end
+
+    def execution_id=(id)
+      Thread.current[:chitragupta_rake_execution_id] = id
+    end
   end
 end

--- a/lib/chitragupta/rake/application.rb
+++ b/lib/chitragupta/rake/application.rb
@@ -1,19 +1,23 @@
 require 'rake'
 module Rake
   class Application
+    # Threads spawned inside a task have no context of their own, so they read
+    # the last context set by the application.
     def current_task
-      Thread.current[:chitragupta_rake_current_task]
+      Thread.current[:chitragupta_rake_current_task] || @current_task
     end
 
     def current_task=(task)
+      @current_task = task
       Thread.current[:chitragupta_rake_current_task] = task
     end
 
     def execution_id
-      Thread.current[:chitragupta_rake_execution_id]
+      Thread.current[:chitragupta_rake_execution_id] || @execution_id
     end
 
     def execution_id=(id)
+      @execution_id = id
       Thread.current[:chitragupta_rake_execution_id] = id
     end
   end

--- a/lib/chitragupta/rake/task.rb
+++ b/lib/chitragupta/rake/task.rb
@@ -12,6 +12,7 @@ module Chitragupta
       super
     ensure
       Thread.current[:chitragupta_rake_context_depth] = depth
+      # Only nested tasks restore: hosts read current_task after a top-level invoke returns.
       if depth > 0
         Rake.application.current_task = previous_task
         Rake.application.execution_id = previous_execution_id

--- a/lib/chitragupta/rake/task.rb
+++ b/lib/chitragupta/rake/task.rb
@@ -1,12 +1,23 @@
 require "chitragupta/rake/application"
 
-module Rake
-  class Task
-    alias :old_execute :execute 
+module Chitragupta
+  module RakeTask
     def execute(args=nil)
+      depth = Thread.current[:chitragupta_rake_context_depth] || 0
+      previous_task = Rake.application.current_task
+      previous_execution_id = Rake.application.execution_id
+      Thread.current[:chitragupta_rake_context_depth] = depth + 1
       Rake.application.current_task = @name
       Rake.application.execution_id = Chitragupta.get_unique_log_id
-      old_execute(args)
+      super
+    ensure
+      Thread.current[:chitragupta_rake_context_depth] = depth
+      if depth > 0
+        Rake.application.current_task = previous_task
+        Rake.application.execution_id = previous_execution_id
+      end
     end
   end
 end
+
+Rake::Task.prepend(Chitragupta::RakeTask)

--- a/lib/chitragupta/util.rb
+++ b/lib/chitragupta/util.rb
@@ -49,7 +49,8 @@ module Chitragupta
       data[:data][:request][:ip] = Chitragupta.payload[:ip]
       data[:data][:request][:id] = Chitragupta.payload[:request_id]
       data[:data][:request][:user_id] = Chitragupta.payload[:user_id]
-      data[:data][:request][:params] = Chitragupta.payload[:params]
+      params = Chitragupta.payload[:params]
+      data[:data][:request][:params] = params.is_a?(String) ? params : params.to_json
 
       data[:data][:response][:status] = message[:status] rescue nil
       data[:data][:response][:duration] = message[:duration] rescue nil

--- a/lib/chitragupta/util.rb
+++ b/lib/chitragupta/util.rb
@@ -49,7 +49,7 @@ module Chitragupta
       data[:data][:request][:ip] = Chitragupta.payload[:ip]
       data[:data][:request][:id] = Chitragupta.payload[:request_id]
       data[:data][:request][:user_id] = Chitragupta.payload[:user_id]
-      data[:data][:request][:params] = Chitragupta.payload[:params].to_json.to_s
+      data[:data][:request][:params] = Chitragupta.payload[:params]
 
       data[:data][:response][:status] = message[:status] rescue nil
       data[:data][:response][:duration] = message[:duration] rescue nil

--- a/lib/chitragupta/version.rb
+++ b/lib/chitragupta/version.rb
@@ -1,3 +1,3 @@
 module Chitragupta
-  VERSION = "0.4.6"
+  VERSION = "0.4.7"
 end

--- a/spec/chitragupta/middleware_spec.rb
+++ b/spec/chitragupta/middleware_spec.rb
@@ -3,8 +3,6 @@ require "chitragupta"
 require "chitragupta/middleware"
 
 RSpec.describe Chitragupta::Middleware do
-  let(:app) { lambda { |env| [200, {}, env] } }
-
   it "clears context inherited from an earlier request on the same thread" do
     Chitragupta.payload = { request_id: "previous" }
     seen = nil
@@ -13,10 +11,33 @@ RSpec.describe Chitragupta::Middleware do
     expect(seen).to eq({})
   end
 
-  it "clears context on the way out and returns the app response" do
-    Chitragupta.payload = { request_id: "previous" }
+  it "keeps the current context until the response body closes" do
+    body = Class.new do
+      attr_reader :during_each, :during_close
 
-    expect(described_class.new(app).call(:env)).to eq([200, {}, :env])
+      def each
+        @during_each = Chitragupta.payload.dup
+        yield "chunk"
+      end
+
+      def close
+        @during_close = Chitragupta.payload.dup
+      end
+    end.new
+    app = lambda do |_env|
+      Chitragupta.payload = { request_id: "current" }
+      [200, {}, body]
+    end
+
+    response = described_class.new(app).call({})
+    expect(response[0, 2]).to eq([200, {}])
+    expect(Chitragupta.payload).to eq({ request_id: "current" })
+
+    response[2].each { |_| }
+    expect(body.during_each).to eq({ request_id: "current" })
+
+    response[2].close
+    expect(body.during_close).to eq({ request_id: "current" })
     expect(Chitragupta.payload).to eq({})
   end
 
@@ -24,6 +45,25 @@ RSpec.describe Chitragupta::Middleware do
     failing = lambda { |_env| Chitragupta.payload = { request_id: "current" }; raise "boom" }
 
     expect { described_class.new(failing).call({}) }.to raise_error("boom")
+    expect(Chitragupta.payload).to eq({})
+  end
+
+  it "clears context when closing the response body raises" do
+    body = Class.new do
+      def each
+      end
+
+      def close
+        raise "close boom"
+      end
+    end.new
+    app = lambda do |_env|
+      Chitragupta.payload = { request_id: "current" }
+      [200, {}, body]
+    end
+
+    response = described_class.new(app).call({})
+    expect { response[2].close }.to raise_error("close boom")
     expect(Chitragupta.payload).to eq({})
   end
 end

--- a/spec/chitragupta/middleware_spec.rb
+++ b/spec/chitragupta/middleware_spec.rb
@@ -1,0 +1,29 @@
+require "logger"
+require "chitragupta"
+require "chitragupta/middleware"
+
+RSpec.describe Chitragupta::Middleware do
+  let(:app) { lambda { |env| [200, {}, env] } }
+
+  it "clears context inherited from an earlier request on the same thread" do
+    Chitragupta.payload = { request_id: "previous" }
+    seen = nil
+    described_class.new(lambda { |env| seen = Chitragupta.payload.dup; [200, {}, env] }).call({})
+
+    expect(seen).to eq({})
+  end
+
+  it "clears context on the way out and returns the app response" do
+    Chitragupta.payload = { request_id: "previous" }
+
+    expect(described_class.new(app).call(:env)).to eq([200, {}, :env])
+    expect(Chitragupta.payload).to eq({})
+  end
+
+  it "clears context when the app raises" do
+    failing = lambda { |_env| Chitragupta.payload = { request_id: "current" }; raise "boom" }
+
+    expect { described_class.new(failing).call({}) }.to raise_error("boom")
+    expect(Chitragupta.payload).to eq({})
+  end
+end

--- a/spec/chitragupta/rake_task_spec.rb
+++ b/spec/chitragupta/rake_task_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe "Chitragupta Rake task context" do
     expect(context.last).to eq(Rake.application.execution_id)
   end
 
+  it "keeps task attribution in threads the task spawns" do
+    context = nil
+    Rake::Task.define_task(:spawns_thread) do
+      Thread.new do
+        context = [Rake.application.current_task, Rake.application.execution_id]
+      end.join
+    end
+
+    Rake::Task[:spawns_thread].invoke
+
+    expect(context).to eq(["spawns_thread", Rake.application.execution_id])
+  end
+
   it "isolates concurrently executing tasks" do
     ready = Queue.new
     release = Queue.new

--- a/spec/chitragupta/rake_task_spec.rb
+++ b/spec/chitragupta/rake_task_spec.rb
@@ -1,0 +1,84 @@
+require "logger"
+require "chitragupta"
+require "rake"
+require "chitragupta/rake/task"
+
+RSpec.describe "Chitragupta Rake task context" do
+  around do |example|
+    application = Rake.application
+    Rake.application = Rake::Application.new
+    example.run
+  ensure
+    Rake.application = application
+  end
+
+  it "preserves the completed top-level task context" do
+    Rake::Task.define_task(:top_level)
+
+    Rake::Task[:top_level].invoke
+
+    expect(Rake.application.current_task).to eq("top_level")
+    expect(Rake.application.execution_id).not_to be_nil
+  end
+
+  it "restores the outer task context after a nested task" do
+    contexts = []
+    Rake::Task.define_task(:inner) do
+      contexts << [Rake.application.current_task, Rake.application.execution_id]
+    end
+    Rake::Task.define_task(:outer) do
+      contexts << [Rake.application.current_task, Rake.application.execution_id]
+      Rake::Task[:inner].invoke
+      contexts << [Rake.application.current_task, Rake.application.execution_id]
+    end
+
+    Rake::Task[:outer].invoke
+
+    expect(contexts.map(&:first)).to eq(%w[outer inner outer])
+    expect(contexts[0].last).to eq(contexts[2].last)
+    expect(contexts[0].last).not_to eq(contexts[1].last)
+  end
+
+  it "restores the outer task context when a nested task fails" do
+    context = nil
+    Rake::Task.define_task(:failing_inner) { raise "failure" }
+    Rake::Task.define_task(:rescuing_outer) do
+      begin
+        Rake::Task[:failing_inner].invoke
+      rescue RuntimeError
+        context = [Rake.application.current_task, Rake.application.execution_id]
+      end
+    end
+
+    Rake::Task[:rescuing_outer].invoke
+
+    expect(context.first).to eq("rescuing_outer")
+    expect(context.last).to eq(Rake.application.execution_id)
+  end
+
+  it "isolates concurrently executing tasks" do
+    ready = Queue.new
+    release = Queue.new
+    contexts = Queue.new
+    %i[first second].each do |name|
+      Rake::Task.define_task(name) do
+        ready << true
+        release.pop
+        contexts << [name.to_s, Rake.application.current_task, Rake.application.execution_id]
+      end
+    end
+    Rake::MultiTask.define_task(all: %i[first second])
+
+    execution = Thread.new { Rake::Task[:all].invoke }
+    2.times { ready.pop }
+    2.times { release << true }
+    execution.join
+    results = 2.times.map { contexts.pop }.sort
+
+    expect(results.map { |expected, actual, _id| [expected, actual] }).to eq([
+      %w[first first],
+      %w[second second]
+    ])
+    expect(results.map(&:last).uniq.length).to eq(2)
+  end
+end

--- a/spec/chitragupta/request_params_spec.rb
+++ b/spec/chitragupta/request_params_spec.rb
@@ -1,0 +1,26 @@
+require "json"
+require "logger"
+require "chitragupta"
+
+RSpec.describe "Chitragupta request params logging" do
+  let(:formatter) { Chitragupta::JsonLogFormatter.new }
+
+  before do
+    allow(Chitragupta::Util).to receive(:called_as_rails_server?).and_return(true)
+  end
+
+  def emitted_params(params)
+    Chitragupta.payload = { method: "POST", path: "/login", ip: "1.2.3.4",
+                            request_id: "r1", user_id: 1, params: params }
+    record = JSON.parse(formatter.call("INFO", Time.now, nil, { status: 200 }))
+    record["data"]["request"]["params"]
+  end
+
+  it "serializes the hash a rack host supplies" do
+    expect(emitted_params({ "user" => "a", "page" => 2 })).to eq('{"user":"a","page":2}')
+  end
+
+  it "emits already serialized params exactly once" do
+    expect(emitted_params('{"user":"a"}')).to eq('{"user":"a"}')
+  end
+end

--- a/spec/chitragupta/util_spec.rb
+++ b/spec/chitragupta/util_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Chitragupta::Util do
   context 'populate_rails_server_data' do
 
     before(:each) do
-      Chitragupta.payload = {method: "GET", path: "/", controller: "TestController", action: "dummy", ip: "127.0.0.1", request_id: "123asd", user_id: 1, params: {a: 1}}
+      Chitragupta.payload = {method: "GET", path: "/", controller: "TestController", action: "dummy", ip: "127.0.0.1", request_id: "123asd", user_id: 1, params: '{"a":1}'}
     end
 
     it 'should populate all the required key values for server request and nil for missing message values' do


### PR DESCRIPTION
Logging-context and encoding fixes for the Rails SDK, released together as `0.4.7`.

- **[DATA-11949](https://browserstack.atlassian.net/browse/DATA-11949) — stale request context across reused threads**
  - Add `Chitragupta::Middleware`, which clears the thread-local payload on request entry and again on exit.
  - Install it outermost with `config.middleware.insert_before 0`. An index needs no reference middleware, so it is safe on Rails 4.0, the entry clear runs before any other middleware can log, and the exit clear runs after exception-logging middleware such as `ActionDispatch::DebugExceptions` has read the context.
- **[DATA-12991](https://browserstack.atlassian.net/browse/DATA-12991) — Rake task attribution under parallel execution**
  - Store `current_task` and `execution_id` per thread so concurrent tasks keep their own name and ID.
  - Restore the outer task's context after nested invocations and after failures, while leaving the completed top-level context readable for existing monitoring. A host that reads `current_task` after a *nested* `invoke` returns now sees the outer task rather than the inner one; zombies/reportApp does this and pins `v0.2.1`, so it is unaffected until it repins.
  - Fall back to the last task context in threads a task spawns, so their log lines stay attributed. Under `multitask` a spawned thread can still inherit a sibling task's context, unchanged from current behaviour.
- **[DATA-12985](https://browserstack.atlassian.net/browse/DATA-12985) — unsanitised `request-source` header**
  - Remove the capture: the value was stored in the request payload but never emitted in any log record, so nothing reached a log sink.
- **[DATA-12973](https://browserstack.atlassian.net/browse/DATA-12973) — unfiltered params in the Rack integration**
  - Point the README Rack/Sinatra example at params the host has already filtered, rather than raw `request.params`. This is the only integration path the gem does not filter on the host's behalf, and a snippet-level denylist would miss nested keys.
- **Off-ticket — double-encoded request params**
  - Emit the subscriber's already-serialised params once instead of re-serialising them, and serialise the hash a Rack host supplies. This changes `data.request.params` on the wire from a doubly-escaped string to a single JSON string, so any downstream parser that currently parses it twice needs updating.
- **Release**
  - Bump the version from `0.4.6` to `0.4.7`.

Tested with `bundle exec rspec` plus the Rake specs against the exact versions the consumers pin, `10.1.1` and `13.0.3`.


[DATA-11949]: https://browserstack.atlassian.net/browse/DATA-11949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DATA-12991]: https://browserstack.atlassian.net/browse/DATA-12991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DATA-12985]: https://browserstack.atlassian.net/browse/DATA-12985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DATA-12973]: https://browserstack.atlassian.net/browse/DATA-12973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ