### PR TITLE
DATA-12991: Isolate Rake task logging context

### DIFF
--- a/lib/chitragupta/rake/application.rb
+++ b/lib/chitragupta/rake/application.rb
@@ -1,6 +1,20 @@
 require 'rake'
 module Rake
   class Application
-    attr_accessor :current_task, :execution_id
+    def current_task
+      Thread.current[:chitragupta_rake_current_task]
+    end
+
+    def current_task=(task)
+      Thread.current[:chitragupta_rake_current_task] = task
+    end
+
+    def execution_id
+      Thread.current[:chitragupta_rake_execution_id]
+    end
+
+    def execution_id=(id)
+      Thread.current[:chitragupta_rake_execution_id] = id
+    end
   end
 end

--- a/lib/chitragupta/rake/task.rb
+++ b/lib/chitragupta/rake/task.rb
@@ -1,12 +1,23 @@
 require "chitragupta/rake/application"
 
-module Rake
-  class Task
-    alias :old_execute :execute 
+module Chitragupta
+  module RakeTask
     def execute(args=nil)
+      depth = Thread.current[:chitragupta_rake_context_depth] || 0
+      previous_task = Rake.application.current_task
+      previous_execution_id = Rake.application.execution_id
+      Thread.current[:chitragupta_rake_context_depth] = depth + 1
       Rake.application.current_task = @name
       Rake.application.execution_id = Chitragupta.get_unique_log_id
-      old_execute(args)
+      super
+    ensure
+      Thread.current[:chitragupta_rake_context_depth] = depth
+      if depth > 0
+        Rake.application.current_task = previous_task
+        Rake.application.execution_id = previous_execution_id
+      end
     end
   end
 end
+
+Rake::Task.prepend(Chitragupta::RakeTask)

--- a/spec/chitragupta/rake_task_spec.rb
+++ b/spec/chitragupta/rake_task_spec.rb
@@ -1,0 +1,84 @@
+require "logger"
+require "chitragupta"
+require "rake"
+require "chitragupta/rake/task"
+
+RSpec.describe "Chitragupta Rake task context" do
+  around do |example|
+    application = Rake.application
+    Rake.application = Rake::Application.new
+    example.run
+  ensure
+    Rake.application = application
+  end
+
+  it "preserves the completed top-level task context" do
+    Rake::Task.define_task(:top_level)
+
+    Rake::Task[:top_level].invoke
+
+    expect(Rake.application.current_task).to eq("top_level")
+    expect(Rake.application.execution_id).not_to be_nil
+  end
+
+  it "restores the outer task context after a nested task" do
+    contexts = []
+    Rake::Task.define_task(:inner) do
+      contexts << [Rake.application.current_task, Rake.application.execution_id]
+    end
+    Rake::Task.define_task(:outer) do
+      contexts << [Rake.application.current_task, Rake.application.execution_id]
+      Rake::Task[:inner].invoke
+      contexts << [Rake.application.current_task, Rake.application.execution_id]
+    end
+
+    Rake::Task[:outer].invoke
+
+    expect(contexts.map(&:first)).to eq(%w[outer inner outer])
+    expect(contexts[0].last).to eq(contexts[2].last)
+    expect(contexts[0].last).not_to eq(contexts[1].last)
+  end
+
+  it "restores the outer task context when a nested task fails" do
+    context = nil
+    Rake::Task.define_task(:failing_inner) { raise "failure" }
+    Rake::Task.define_task(:rescuing_outer) do
+      begin
+        Rake::Task[:failing_inner].invoke
+      rescue RuntimeError
+        context = [Rake.application.current_task, Rake.application.execution_id]
+      end
+    end
+
+    Rake::Task[:rescuing_outer].invoke
+
+    expect(context.first).to eq("rescuing_outer")
+    expect(context.last).to eq(Rake.application.execution_id)
+  end
+
+  it "isolates concurrently executing tasks" do
+    ready = Queue.new
+    release = Queue.new
+    contexts = Queue.new
+    %i[first second].each do |name|
+      Rake::Task.define_task(name) do
+        ready << true
+        release.pop
+        contexts << [name.to_s, Rake.application.current_task, Rake.application.execution_id]
+      end
+    end
+    Rake::MultiTask.define_task(all: %i[first second])
+
+    execution = Thread.new { Rake::Task[:all].invoke }
+    2.times { ready.pop }
+    2.times { release << true }
+    execution.join
+    results = 2.times.map { contexts.pop }.sort
+
+    expect(results.map { |expected, actual, _id| [expected, actual] }).to eq([
+      %w[first first],
+      %w[second second]
+    ])
+    expect(results.map(&:last).uniq.length).to eq(2)
+  end
+end


### PR DESCRIPTION
Fixes [DATA-12991](https://browserstack.atlassian.net/browse/DATA-12991).

Ensures concurrent and nested Rake tasks keep the correct task name and execution ID in logs.

Changes:
- Store Rake attribution in thread-local context.
- Restore outer context after nested success or failure while preserving completed top-level context.
- Add deterministic coverage for parallel, nested, exception, and post-invocation behavior.

Validation:
- Focused spec passes on Rake 10.1.1 and 13.0.3 (4 examples).
- The full suite retains its pre-existing baseline: 28 examples, 12 failures, 1 pending.

Merge after #29; add the `v0.4.8` version bump once `v0.4.7` lands.


[DATA-12991]: https://browserstack.atlassian.net/browse/DATA-12991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ